### PR TITLE
Add custom header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ go build -o proxy
 
 ```sh
 ./proxy -target http://localhost:9000 -http :8080 \
-        -https :8443 -cert path/to/cert.pem -key path/to/key.pem
+        -https :8443 -cert path/to/cert.pem -key path/to/key.pem \
+        -header "X-Example=1" -header "X-Other=2"
 ```
 
 ### Flags
@@ -23,6 +24,7 @@ go build -o proxy
 - `-https` – HTTPS listen address. Disabled if empty.
 - `-cert` – TLS certificate file used with `-https`.
 - `-key` – TLS key file used with `-https`.
+- `-header` – Custom header to add to upstream requests. Can be repeated.
 
 ## Testing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,4 +7,5 @@ type Config struct {
 	HTTPSAddr string
 	CertFile  string
 	KeyFile   string
+	Headers   map[string]string
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9,13 +9,14 @@ import (
 )
 
 // New creates a reverse proxy to the given target URL.
-func New(target *url.URL, logger *log.Logger) *httputil.ReverseProxy {
+func New(target *url.URL, logger *log.Logger, headers map[string]string) *httputil.ReverseProxy {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		originalDirector(req)
-		// Example: force a specific header for all upstream requests
-		req.Header.Set("X-Forwarded-By", "MyGoProxy")
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
 	}
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -17,7 +17,7 @@ func newLogger() *log.Logger {
 func TestNewAddsHeader(t *testing.T) {
 	var received string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		received = r.Header.Get("X-Forwarded-By")
+		received = r.Header.Get("X-Test")
 	}))
 	defer backend.Close()
 
@@ -26,7 +26,8 @@ func TestNewAddsHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp := New(u, newLogger())
+	headers := map[string]string{"X-Test": "value"}
+	rp := New(u, newLogger(), headers)
 	proxySrv := httptest.NewServer(rp)
 	defer proxySrv.Close()
 
@@ -36,14 +37,14 @@ func TestNewAddsHeader(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	if received != "MyGoProxy" {
-		t.Fatalf("expected header 'MyGoProxy', got %q", received)
+	if received != "value" {
+		t.Fatalf("expected header 'value', got %q", received)
 	}
 }
 
 func TestErrorHandlerReturnsBadGateway(t *testing.T) {
 	u, _ := url.Parse("http://127.0.0.1:1")
-	rp := New(u, newLogger())
+	rp := New(u, newLogger(), nil)
 	proxySrv := httptest.NewServer(rp)
 	defer proxySrv.Close()
 

--- a/main.go
+++ b/main.go
@@ -2,14 +2,38 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/pod32g/proxy/internal/config"
 	"github.com/pod32g/proxy/internal/proxy"
 	"github.com/pod32g/proxy/internal/server"
 	log "github.com/pod32g/simple-logger"
 )
+
+type headerFlags map[string]string
+
+func (h *headerFlags) String() string {
+	var parts []string
+	for k, v := range *h {
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (h *headerFlags) Set(value string) error {
+	if *h == nil {
+		*h = make(map[string]string)
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid header %q", value)
+	}
+	(*h)[parts[0]] = parts[1]
+	return nil
+}
 
 func main() {
 	cfg := config.Config{}
@@ -18,7 +42,11 @@ func main() {
 	flag.StringVar(&cfg.HTTPSAddr, "https", "", "HTTPS listen address")
 	flag.StringVar(&cfg.CertFile, "cert", "", "TLS certificate file")
 	flag.StringVar(&cfg.KeyFile, "key", "", "TLS key file")
+	var headers headerFlags
+	flag.Var(&headers, "header", "Custom header to add to upstream requests (format Name=Value, can be repeated)")
 	flag.Parse()
+
+	cfg.Headers = headers
 
 	logger := log.NewLogger(os.Stdout, log.INFO, &log.DefaultFormatter{})
 
@@ -27,7 +55,7 @@ func main() {
 		logger.Fatal("Invalid backend URL: %v", err)
 	}
 
-	handler := proxy.New(target, logger)
+	handler := proxy.New(target, logger, cfg.Headers)
 
 	srv := server.Server{
 		HTTPAddr:  cfg.HTTPAddr,


### PR DESCRIPTION
## Summary
- support user-supplied headers in the proxy
- parse repeated `-header` flags from the CLI
- document new flag and usage in README
- test custom header behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6841df0d06c48330a782567c063005d5