### PR TITLE
Add forward proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Go HTTP Reverse Proxy
+# Go HTTP Proxy
 
-This project provides a minimal reverse proxy written in Go. It can forward HTTP
-requests to a configurable backend and optionally serve HTTPS traffic.
+This project provides a minimal HTTP proxy written in Go. It can operate as a traditional forward proxy or as a reverse proxy forwarding requests to a configurable backend. HTTPS traffic can be proxied without providing a certificate when running in forward mode.
 
 ## Building
 
@@ -12,7 +11,7 @@ go build -o proxy
 ## Usage
 
 ```sh
-./proxy -target http://localhost:9000 -http :8080 \
+./proxy -mode reverse -target http://localhost:9000 -http :8080 \
         -https :8443 -cert path/to/cert.pem -key path/to/key.pem \
         -header "X-Example=1" -header "X-Other=2"
 ```
@@ -25,6 +24,7 @@ go build -o proxy
 - `-cert` – TLS certificate file used with `-https`.
 - `-key` – TLS key file used with `-https`.
 - `-header` – Custom header to add to upstream requests. Can be repeated.
+- `-mode` – Proxy mode: `forward` or `reverse`. Defaults to `forward`.
 
 ## Testing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 // Config holds the runtime configuration for the proxy server.
 type Config struct {
+	// Mode determines whether the proxy runs in "reverse" or "forward" mode.
+	Mode      string
 	TargetURL string
 	HTTPAddr  string
 	HTTPSAddr string

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1,0 +1,81 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+
+	log "github.com/pod32g/simple-logger"
+)
+
+// NewForward creates a forward proxy handler. It supports HTTPS via CONNECT
+// without requiring TLS certificates.
+func NewForward(logger *log.Logger, headers map[string]string) http.Handler {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			handleConnect(w, r, logger)
+			return
+		}
+		outReq := r.Clone(r.Context())
+		outReq.RequestURI = ""
+		for k, v := range headers {
+			outReq.Header.Set(k, v)
+		}
+		resp, err := transport.RoundTrip(outReq)
+		if err != nil {
+			logger.Error("Upstream Error: %v", err)
+			http.Error(w, "Bad gateway", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	})
+}
+
+func handleConnect(w http.ResponseWriter, r *http.Request, logger *log.Logger) {
+	destConn, err := net.Dial("tcp", r.Host)
+	if err != nil {
+		logger.Error("CONNECT dial error: %v", err)
+		http.Error(w, "Bad gateway", http.StatusBadGateway)
+		return
+	}
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		destConn.Close()
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		logger.Error("Hijack error: %v", err)
+		http.Error(w, "Hijack failed", http.StatusInternalServerError)
+		destConn.Close()
+		return
+	}
+	_, err = io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+	if err != nil {
+		destConn.Close()
+		clientConn.Close()
+		return
+	}
+	go transfer(destConn, clientConn)
+	go transfer(clientConn, destConn)
+}
+
+func transfer(dst io.WriteCloser, src io.ReadCloser) {
+	io.Copy(dst, src)
+	dst.Close()
+	src.Close()
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `-mode` flag to choose forward or reverse proxy (default to forward)
- implement `NewForward` handler with HTTPS CONNECT support
- document proxy modes and usage
- extend tests for forward proxy
- set forward proxy as default mode

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_6841e0394534833084541e263faeaf3b