### PR TITLE
Add web UI and env-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ go build -o proxy
         -header "X-Example=1" -header "X-Other=2"
 ```
 
-### Flags
+### Flags and environment variables
 
-- `-target` – Backend server URL. Defaults to `http://localhost:9000`.
-- `-http` – HTTP listen address. Defaults to `:8080`.
-- `-https` – HTTPS listen address. Disabled if empty.
-- `-cert` – TLS certificate file used with `-https`.
-- `-key` – TLS key file used with `-https`.
+- `-target` – Backend server URL. Defaults to `http://localhost:9000` or `PROXY_TARGET`.
+- `-http` – HTTP listen address. Defaults to `:8080` or `PROXY_HTTP_ADDR`.
+- `-https` – HTTPS listen address. Disabled if empty. Can be set with `PROXY_HTTPS_ADDR`.
+- `-cert` – TLS certificate file used with `-https`. Can be set with `PROXY_CERT_FILE`.
+- `-key` – TLS key file used with `-https`. Can be set with `PROXY_KEY_FILE`.
 - `-header` – Custom header to add to upstream requests. Can be repeated.
-- `-mode` – Proxy mode: `forward` or `reverse`. Defaults to `forward`.
+- `-mode` – Proxy mode: `forward` or `reverse`. Defaults to `forward` or `PROXY_MODE`.
+
+### Web UI
+
+A simple configuration UI is available at `/ui`. It allows adding, updating and deleting custom headers while the proxy is running.
 
 ## Testing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 // Config holds the runtime configuration for the proxy server.
+import "sync"
+
+// Config holds the runtime configuration for the proxy server.
 type Config struct {
 	// Mode determines whether the proxy runs in "reverse" or "forward" mode.
 	Mode      string
@@ -9,5 +12,36 @@ type Config struct {
 	HTTPSAddr string
 	CertFile  string
 	KeyFile   string
-	Headers   map[string]string
+
+	Headers map[string]string
+
+	mu sync.RWMutex
+}
+
+// SetHeader adds or updates a header in the config in a thread-safe manner.
+func (c *Config) SetHeader(name, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Headers == nil {
+		c.Headers = make(map[string]string)
+	}
+	c.Headers[name] = value
+}
+
+// DeleteHeader removes a header from the config.
+func (c *Config) DeleteHeader(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.Headers, name)
+}
+
+// GetHeaders returns a copy of the configured headers.
+func (c *Config) GetHeaders() map[string]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[string]string, len(c.Headers))
+	for k, v := range c.Headers {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -9,8 +9,9 @@ import (
 )
 
 // NewForward creates a forward proxy handler. It supports HTTPS via CONNECT
-// without requiring TLS certificates.
-func NewForward(logger *log.Logger, headers map[string]string) http.Handler {
+// without requiring TLS certificates. The headers function returns the headers
+// that should be added to outbound requests.
+func NewForward(logger *log.Logger, headers func() map[string]string) http.Handler {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = nil
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +21,7 @@ func NewForward(logger *log.Logger, headers map[string]string) http.Handler {
 		}
 		outReq := r.Clone(r.Context())
 		outReq.RequestURI = ""
-		for k, v := range headers {
+		for k, v := range headers() {
 			outReq.Header.Set(k, v)
 		}
 		resp, err := transport.RoundTrip(outReq)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9,12 +9,13 @@ import (
 )
 
 // New creates a reverse proxy to the given target URL.
-func New(target *url.URL, logger *log.Logger, headers map[string]string) *httputil.ReverseProxy {
+// The headers function should return the headers to set on each upstream request.
+func New(target *url.URL, logger *log.Logger, headers func() map[string]string) *httputil.ReverseProxy {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		originalDirector(req)
-		for k, v := range headers {
+		for k, v := range headers() {
 			req.Header.Set(k, v)
 		}
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -31,7 +31,7 @@ func TestNewAddsHeader(t *testing.T) {
 	}
 
 	headers := map[string]string{"X-Test": "value"}
-	rp := New(u, newLogger(), headers)
+	rp := New(u, newLogger(), func() map[string]string { return headers })
 	proxySrv := httptest.NewServer(rp)
 	defer proxySrv.Close()
 
@@ -48,7 +48,7 @@ func TestNewAddsHeader(t *testing.T) {
 
 func TestErrorHandlerReturnsBadGateway(t *testing.T) {
 	u, _ := url.Parse("http://127.0.0.1:1")
-	rp := New(u, newLogger(), nil)
+	rp := New(u, newLogger(), func() map[string]string { return nil })
 	proxySrv := httptest.NewServer(rp)
 	defer proxySrv.Close()
 
@@ -69,7 +69,7 @@ func TestForwardAddsHeader(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	fp := NewForward(newLogger(), map[string]string{"X-Test": "value"})
+	fp := NewForward(newLogger(), func() map[string]string { return map[string]string{"X-Test": "value"} })
 	proxySrv := httptest.NewServer(fp)
 	defer proxySrv.Close()
 
@@ -102,7 +102,7 @@ func TestForwardConnect(t *testing.T) {
 		close(done)
 	}()
 
-	fp := NewForward(newLogger(), nil)
+	fp := NewForward(newLogger(), func() map[string]string { return nil })
 	proxySrv := httptest.NewServer(fp)
 	defer proxySrv.Close()
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"html/template"
+	"net/http"
+
+	"github.com/pod32g/proxy/internal/config"
+)
+
+// New returns a handler that exposes a simple configuration UI.
+func New(cfg *config.Config) http.Handler {
+	h := &handler{cfg: cfg}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", h.index)
+	mux.HandleFunc("/header", h.addHeader)
+	mux.HandleFunc("/delete", h.deleteHeader)
+	return mux
+}
+
+type handler struct {
+	cfg *config.Config
+}
+
+var page = template.Must(template.New("index").Parse(`<!DOCTYPE html>
+<html><head><title>Proxy Config</title></head><body>
+<h1>Headers</h1>
+<table>
+{{range $k, $v := .}}
+<tr><td>{{$k}}</td><td>{{$v}}</td></tr>
+{{end}}
+</table>
+<h2>Add/Update Header</h2>
+<form method="POST" action="/header">
+Name: <input name="name">
+Value: <input name="value">
+<button type="submit">Save</button>
+</form>
+<h2>Delete Header</h2>
+<form method="POST" action="/delete">
+Name: <input name="name">
+<button type="submit">Delete</button>
+</form>
+</body></html>`))
+
+func (h *handler) index(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.NotFound(w, r)
+		return
+	}
+	page.Execute(w, h.cfg.GetHeaders())
+}
+
+func (h *handler) addHeader(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	name := r.FormValue("name")
+	value := r.FormValue("value")
+	if name != "" {
+		h.cfg.SetHeader(name, value)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (h *handler) deleteHeader(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	name := r.FormValue("name")
+	if name != "" {
+		h.cfg.DeleteHeader(name)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}


### PR DESCRIPTION
## Summary
- add thread-safe config with header management helpers
- implement configurable web UI at /ui for adding/removing headers
- pass headers via provider functions to proxy handlers
- support PROXY_* environment variables for command defaults
- document new environment variables and web UI in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6841e205a8e083309a9ffd3b9486ef5b