### PR TITLE
Add request debug logs

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -16,9 +16,11 @@ func NewForward(logger *log.Logger, headers func() map[string]string) http.Handl
 	transport.Proxy = nil
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodConnect {
+			logger.Debug("CONNECT request", r.Host)
 			handleConnect(w, r, logger)
 			return
 		}
+		logger.Debug("Forward proxy request", r.Method, sanitizedURL(r.URL))
 		outReq := r.Clone(r.Context())
 		outReq.RequestURI = ""
 		for k, v := range headers() {
@@ -38,6 +40,7 @@ func NewForward(logger *log.Logger, headers func() map[string]string) http.Handl
 }
 
 func handleConnect(w http.ResponseWriter, r *http.Request, logger *log.Logger) {
+	logger.Debug("CONNECT tunnel", r.Host)
 	destConn, err := net.Dial("tcp", r.Host)
 	if err != nil {
 		logger.Error("CONNECT dial error: %v", err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8,12 +8,17 @@ import (
 	log "github.com/pod32g/simple-logger"
 )
 
+func sanitizedURL(u *url.URL) string {
+	return u.Scheme + "://" + u.Host + u.Path
+}
+
 // New creates a reverse proxy to the given target URL.
 // The headers function should return the headers to set on each upstream request.
 func New(target *url.URL, logger *log.Logger, headers func() map[string]string) *httputil.ReverseProxy {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
+		logger.Debug("Reverse proxy request", req.Method, sanitizedURL(req.URL))
 		originalDirector(req)
 		for k, v := range headers() {
 			req.Header.Set(k, v)


### PR DESCRIPTION
## Summary
- add helper to sanitize URLs for logging
- log reverse proxy requests at debug level
- log forward proxy requests and CONNECT tunnels at debug level

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6841f0e92b5883308ad918f08c677162