### PR TITLE
Fix missing host/scheme in forward proxy

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -21,6 +21,11 @@ func NewForward(logger *log.Logger, headers func() map[string]string) http.Handl
 			return
 		}
 		logger.Debug("Forward proxy request", r.Method, sanitizedURL(r.URL))
+		if r.URL.Scheme == "" || r.URL.Host == "" {
+			logger.Error("Invalid request URL: missing scheme or host")
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
 		outReq := r.Clone(r.Context())
 		outReq.RequestURI = ""
 		for k, v := range headers() {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -123,3 +123,18 @@ func TestForwardConnect(t *testing.T) {
 	conn.Close()
 	<-done
 }
+
+func TestForwardInvalidRequest(t *testing.T) {
+	fp := NewForward(newLogger(), func() map[string]string { return nil })
+	proxySrv := httptest.NewServer(fp)
+	defer proxySrv.Close()
+
+	resp, err := http.Get(proxySrv.URL + "/favicon.ico")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 status, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- reject invalid forward proxy requests that omit the host or scheme
- test bad request case for forward proxy

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6841f7f2d3c88330951f719ee27d5a5e