### PR TITLE
Fix CONNECT via custom router

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Router dispatches requests between the proxy handler and the UI handler.
+type Router struct {
+	Proxy http.Handler
+	UI    http.Handler
+}
+
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// CONNECT requests never have a path starting with '/'
+	if req.Method != http.MethodConnect && r.UI != nil {
+		if req.URL.Path == "/ui" {
+			http.Redirect(w, req, "/ui/", http.StatusMovedPermanently)
+			return
+		}
+		if strings.HasPrefix(req.URL.Path, "/ui/") {
+			// strip prefix as ServeMux would do
+			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/ui")
+			r.UI.ServeHTTP(w, req)
+			return
+		}
+	}
+	if r.Proxy != nil {
+		r.Proxy.ServeHTTP(w, req)
+	} else {
+		http.NotFound(w, req)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -73,10 +73,8 @@ func main() {
 		}
 		handler = proxy.New(target, logger, cfg.GetHeaders)
 	}
-	mux := http.NewServeMux()
 	uiHandler := ui.New(cfg, logger)
-	mux.Handle("/ui/", http.StripPrefix("/ui", uiHandler))
-	mux.Handle("/", handler)
+	mux := &server.Router{Proxy: handler, UI: uiHandler}
 
 	srv := server.Server{
 		HTTPAddr:  cfg.HTTPAddr,


### PR DESCRIPTION
## Summary
- add a Router that handles CONNECT without ServeMux redirects
- wire the Router into the main server

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- manual curl through proxy

------
https://chatgpt.com/codex/tasks/task_b_6841f90666f083308d4e4f71b2bc81ce