### PR TITLE
Add UI-controllable authentication with encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ go build -o proxy
 ```sh
 ./proxy -mode reverse -target http://localhost:9000 -http :8080 \
         -https :8443 -cert path/to/cert.pem -key path/to/key.pem \
+        -auth -auth-user admin -auth-pass secret -secret mykey \
         -header "X-Example=1" -header "X-Other=2"
 ```
 
@@ -23,6 +24,10 @@ go build -o proxy
 - `-https` – HTTPS listen address. Disabled if empty. Can be set with `PROXY_HTTPS_ADDR`.
 - `-cert` – TLS certificate file used with `-https`. Can be set with `PROXY_CERT_FILE`.
 - `-key` – TLS key file used with `-https`. Can be set with `PROXY_KEY_FILE`.
+- `-auth` – Enable basic authentication. Can be set with `PROXY_AUTH_ENABLED`.
+- `-auth-user` – Username for basic authentication. Can be set with `PROXY_AUTH_USER`.
+- `-auth-pass` – Password for basic authentication. Can be set with `PROXY_AUTH_PASS`.
+- `-secret` – Encryption key used to protect credentials. Can be set with `PROXY_SECRET_KEY`.
 - `-header` – Custom header to add to upstream requests. Can be repeated.
 - `-mode` – Proxy mode: `forward` or `reverse`. Defaults to `forward` or `PROXY_MODE`.
 - `-log-level` – Logging level (`DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`). Defaults to `INFO` or `PROXY_LOG_LEVEL`.
@@ -32,6 +37,7 @@ go build -o proxy
 
 A simple configuration UI is available at `/ui`. It allows adding, updating and deleting custom headers while the proxy is running.
 The UI also lets you change the log level at runtime which overrides the value from the environment or command line.
+Authentication settings (enable/disable and credentials) can also be configured and are stored encrypted in the database.
 
 ## Testing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	CertFile  string
 	KeyFile   string
 
+	Username    string
+	Password    string
+	AuthEnabled bool
+	SecretKey   string
+
 	LogLevel log.LogLevel
 
 	Headers map[string]string
@@ -101,4 +106,24 @@ func LevelString(level log.LogLevel) string {
 	default:
 		return "INFO"
 	}
+}
+
+// SetAuth updates the authentication settings. Empty username or password are ignored.
+func (c *Config) SetAuth(enabled bool, username, password string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.AuthEnabled = enabled
+	if username != "" {
+		c.Username = username
+	}
+	if password != "" {
+		c.Password = password
+	}
+}
+
+// GetAuth returns the current authentication settings.
+func (c *Config) GetAuth() (bool, string, string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.AuthEnabled, c.Username, c.Password
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRouterAuth(t *testing.T) {
+	r := &Router{
+		Proxy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+		AuthEnabled: true,
+		Username:    "user",
+		Password:    "pass",
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Result().StatusCode)
+	}
+
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.SetBasicAuth("user", "pass")
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	if rec2.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec2.Result().StatusCode)
+	}
+
+	cred := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	req3 := httptest.NewRequest("GET", "/", nil)
+	req3.Header.Set("Proxy-Authorization", "Basic "+cred)
+	rec3 := httptest.NewRecorder()
+	r.ServeHTTP(rec3, req3)
+	if rec3.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec3.Result().StatusCode)
+	}
+}
+
+func TestRouterAuthDisabled(t *testing.T) {
+	r := &Router{
+		Proxy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+		AuthEnabled: false,
+		Username:    "user",
+		Password:    "pass",
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Result().StatusCode)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,10 @@ func main() {
 	flag.StringVar(&cfg.HTTPSAddr, "https", getenv("PROXY_HTTPS_ADDR", ""), "HTTPS listen address")
 	flag.StringVar(&cfg.CertFile, "cert", getenv("PROXY_CERT_FILE", ""), "TLS certificate file")
 	flag.StringVar(&cfg.KeyFile, "key", getenv("PROXY_KEY_FILE", ""), "TLS key file")
+	flag.BoolVar(&cfg.AuthEnabled, "auth", getenv("PROXY_AUTH_ENABLED", "") == "true", "enable basic auth")
+	flag.StringVar(&cfg.Username, "auth-user", getenv("PROXY_AUTH_USER", ""), "username for basic auth")
+	flag.StringVar(&cfg.Password, "auth-pass", getenv("PROXY_AUTH_PASS", ""), "password for basic auth")
+	flag.StringVar(&cfg.SecretKey, "secret", getenv("PROXY_SECRET_KEY", ""), "secret key for encryption")
 	logLevelStr := getenv("PROXY_LOG_LEVEL", "INFO")
 	flag.StringVar(&logLevelStr, "log-level", logLevelStr, "Log level (DEBUG, INFO, WARN, ERROR, FATAL)")
 	var headers headerFlags
@@ -86,7 +90,7 @@ func main() {
 		handler = proxy.New(target, logger, cfg.GetHeaders)
 	}
 	uiHandler := ui.New(cfg, store, logger)
-	mux := &server.Router{Proxy: handler, UI: uiHandler}
+	mux := &server.Router{Proxy: handler, UI: uiHandler, AuthEnabled: cfg.AuthEnabled, Username: cfg.Username, Password: cfg.Password}
 
 	srv := server.Server{
 		HTTPAddr:  cfg.HTTPAddr,


### PR DESCRIPTION
## Summary
- allow configuring basic auth and its credentials from the Web UI
- add `AuthEnabled`, `Username`, `Password`, and `SecretKey` options to config
- persist credentials in the sqlite store with AES encryption
- expose new CLI flags and web UI form fields
- update router and tests to honour authentication toggle
- document new flags in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6843346e3b2c8330b444b6c63d4fc035