### PR TITLE
Add client tracking and per-client headers

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -11,7 +11,10 @@ import (
 // NewForward creates a forward proxy handler. It supports HTTPS via CONNECT
 // without requiring TLS certificates. The headers function returns the headers
 // that should be added to outbound requests.
-func NewForward(logger *log.Logger, headers func() map[string]string) http.Handler {
+// NewForward creates a forward proxy handler. It supports HTTPS via CONNECT
+// without requiring TLS certificates. The headers function returns the headers
+// that should be added to outbound requests and receives the client address.
+func NewForward(logger *log.Logger, headers func(string) map[string]string) http.Handler {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = nil
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +31,7 @@ func NewForward(logger *log.Logger, headers func() map[string]string) http.Handl
 		}
 		outReq := r.Clone(r.Context())
 		outReq.RequestURI = ""
-		for k, v := range headers() {
+		for k, v := range headers(r.RemoteAddr) {
 			outReq.Header.Set(k, v)
 		}
 		resp, err := transport.RoundTrip(outReq)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -13,14 +13,14 @@ func sanitizedURL(u *url.URL) string {
 }
 
 // New creates a reverse proxy to the given target URL.
-// The headers function should return the headers to set on each upstream request.
-func New(target *url.URL, logger *log.Logger, headers func() map[string]string) *httputil.ReverseProxy {
+// The headers function receives the client address and returns headers to set on each upstream request.
+func New(target *url.URL, logger *log.Logger, headers func(string) map[string]string) *httputil.ReverseProxy {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		logger.Debug("Reverse proxy request", req.Method, sanitizedURL(req.URL))
 		originalDirector(req)
-		for k, v := range headers() {
+		for k, v := range headers(req.RemoteAddr) {
 			req.Header.Set(k, v)
 		}
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -31,7 +31,7 @@ func TestNewAddsHeader(t *testing.T) {
 	}
 
 	headers := map[string]string{"X-Test": "value"}
-	rp := New(u, newLogger(), func() map[string]string { return headers })
+	rp := New(u, newLogger(), func(string) map[string]string { return headers })
 	proxySrv := httptest.NewServer(rp)
 	defer proxySrv.Close()
 
@@ -48,7 +48,7 @@ func TestNewAddsHeader(t *testing.T) {
 
 func TestErrorHandlerReturnsBadGateway(t *testing.T) {
 	u, _ := url.Parse("http://127.0.0.1:1")
-	rp := New(u, newLogger(), func() map[string]string { return nil })
+	rp := New(u, newLogger(), func(string) map[string]string { return nil })
 	proxySrv := httptest.NewServer(rp)
 	defer proxySrv.Close()
 
@@ -69,7 +69,7 @@ func TestForwardAddsHeader(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	fp := NewForward(newLogger(), func() map[string]string { return map[string]string{"X-Test": "value"} })
+	fp := NewForward(newLogger(), func(string) map[string]string { return map[string]string{"X-Test": "value"} })
 	proxySrv := httptest.NewServer(fp)
 	defer proxySrv.Close()
 
@@ -102,7 +102,7 @@ func TestForwardConnect(t *testing.T) {
 		close(done)
 	}()
 
-	fp := NewForward(newLogger(), func() map[string]string { return nil })
+	fp := NewForward(newLogger(), func(string) map[string]string { return nil })
 	proxySrv := httptest.NewServer(fp)
 	defer proxySrv.Close()
 
@@ -125,7 +125,7 @@ func TestForwardConnect(t *testing.T) {
 }
 
 func TestForwardInvalidRequest(t *testing.T) {
-	fp := NewForward(newLogger(), func() map[string]string { return nil })
+	fp := NewForward(newLogger(), func(string) map[string]string { return nil })
 	proxySrv := httptest.NewServer(fp)
 	defer proxySrv.Close()
 

--- a/internal/server/tracker.go
+++ b/internal/server/tracker.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"sync"
+)
+
+// ClientTracker tracks the number of active client connections.
+type ClientTracker struct {
+	mu   sync.Mutex
+	cnt  int
+	subs map[chan int]struct{}
+}
+
+// NewClientTracker creates a new ClientTracker.
+func NewClientTracker() *ClientTracker {
+	return &ClientTracker{subs: make(map[chan int]struct{})}
+}
+
+// Count returns the current number of active connections.
+func (c *ClientTracker) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cnt
+}
+
+// Subscribe returns a channel that receives connection count updates.
+func (c *ClientTracker) Subscribe() chan int {
+	ch := make(chan int, 1)
+	c.mu.Lock()
+	c.subs[ch] = struct{}{}
+	ch <- c.cnt
+	c.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes the channel from updates.
+func (c *ClientTracker) Unsubscribe(ch chan int) {
+	c.mu.Lock()
+	if _, ok := c.subs[ch]; ok {
+		delete(c.subs, ch)
+		close(ch)
+	}
+	c.mu.Unlock()
+}
+
+func (c *ClientTracker) notify() {
+	for ch := range c.subs {
+		select {
+		case ch <- c.cnt:
+		default:
+		}
+	}
+}
+
+// ConnState is intended to be used as http.Server.ConnState callback.
+func (c *ClientTracker) ConnState(_ net.Conn, state http.ConnState) {
+	switch state {
+	case http.StateNew:
+		c.mu.Lock()
+		c.cnt++
+		c.notify()
+		c.mu.Unlock()
+	case http.StateHijacked, http.StateClosed:
+		c.mu.Lock()
+		if c.cnt > 0 {
+			c.cnt--
+		}
+		c.notify()
+		c.mu.Unlock()
+	}
+}


### PR DESCRIPTION
## Summary
- track active client connections with `ClientTracker`
- expose connected client count via SSE and show it in the UI
- allow per-client custom headers using new config methods
- update proxy handlers and tests for per-client headers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68433a043b3883309f0a9e36a7e9bd1b