### PR TITLE
Add client IP list to web UI

### DIFF
--- a/internal/server/tracker.go
+++ b/internal/server/tracker.go
@@ -8,14 +8,18 @@ import (
 
 // ClientTracker tracks the number of active client connections.
 type ClientTracker struct {
-	mu   sync.Mutex
-	cnt  int
-	subs map[chan int]struct{}
+	mu    sync.Mutex
+	cnt   int
+	subs  map[chan int]struct{}
+	addrs map[string]int
 }
 
 // NewClientTracker creates a new ClientTracker.
 func NewClientTracker() *ClientTracker {
-	return &ClientTracker{subs: make(map[chan int]struct{})}
+	return &ClientTracker{
+		subs:  make(map[chan int]struct{}),
+		addrs: make(map[string]int),
+	}
 }
 
 // Count returns the current number of active connections.
@@ -23,6 +27,17 @@ func (c *ClientTracker) Count() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.cnt
+}
+
+// Addrs returns a slice of client IP addresses currently connected.
+func (c *ClientTracker) Addrs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.addrs))
+	for a := range c.addrs {
+		out = append(out, a)
+	}
+	return out
 }
 
 // Subscribe returns a channel that receives connection count updates.
@@ -55,17 +70,38 @@ func (c *ClientTracker) notify() {
 }
 
 // ConnState is intended to be used as http.Server.ConnState callback.
-func (c *ClientTracker) ConnState(_ net.Conn, state http.ConnState) {
+func (c *ClientTracker) ConnState(conn net.Conn, state http.ConnState) {
+	addr := ""
+	if conn != nil {
+		host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		if err == nil {
+			addr = host
+		} else {
+			addr = conn.RemoteAddr().String()
+		}
+	}
 	switch state {
 	case http.StateNew:
 		c.mu.Lock()
 		c.cnt++
+		if addr != "" {
+			c.addrs[addr]++
+		}
 		c.notify()
 		c.mu.Unlock()
 	case http.StateHijacked, http.StateClosed:
 		c.mu.Lock()
 		if c.cnt > 0 {
 			c.cnt--
+		}
+		if addr != "" {
+			if n, ok := c.addrs[addr]; ok {
+				if n <= 1 {
+					delete(c.addrs, addr)
+				} else {
+					c.addrs[addr] = n - 1
+				}
+			}
 		}
 		c.notify()
 		c.mu.Unlock()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -37,6 +37,7 @@ type pageData struct {
 	AuthEnabled   bool
 	Username      string
 	ClientCount   int
+	ClientAddrs   []string
 }
 
 var page = template.Must(template.New("index").Parse(`<!DOCTYPE html>
@@ -52,6 +53,11 @@ var page = template.Must(template.New("index").Parse(`<!DOCTYPE html>
 </head>
 <body>
 <p>Connected clients: <span id="clients">{{.ClientCount}}</span></p>
+<ul>
+{{range .ClientAddrs}}
+<li>{{.}}</li>
+{{end}}
+</ul>
 <h1>Headers</h1>
 <table>
 <thead><tr><th>Name</th><th>Value</th></tr></thead>
@@ -125,9 +131,11 @@ func (h *handler) index(w http.ResponseWriter, r *http.Request) {
 		AuthEnabled:   enabled,
 		Username:      user,
 		ClientCount:   0,
+		ClientAddrs:   nil,
 	}
 	if h.clients != nil {
 		data.ClientCount = h.clients.Count()
+		data.ClientAddrs = h.clients.Addrs()
 	}
 	page.Execute(w, data)
 }


### PR DESCRIPTION
## Summary
- extend `ClientTracker` to track remote IP addresses
- show connected client addresses on the UI
- update configuration page template

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_684347844c748330a90df546084dc548