### PR TITLE
Refactor UI into separate pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ go build -o proxy
 
 ### Web UI
 
-A simple configuration UI is available at `/ui`. It now features a sidebar menu with sections for general settings, analytics and authentication. You can add, update and delete custom headers while the proxy is running.
+A simple configuration UI is available at `/ui`. It now features a sidebar menu with links to separate pages for general settings, analytics and authentication. You can add, update and delete custom headers while the proxy is running.
 The UI also lets you change the log level at runtime which overrides the value from the environment or command line.
 Authentication settings (enable/disable and credentials) can also be configured and are stored encrypted in the database.
 When enabled, the UI shows the top websites accessed through the proxy.


### PR DESCRIPTION
## Summary
- break UI template into layout with dedicated pages
- add routes for general settings, analytics and auth pages
- update redirects and menu links
- document UI changes in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68435a3881188330a60a4b5711fe9488