### PR TITLE
Fix UI redirect to /ui/general

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -198,7 +198,7 @@ func (h *handler) index(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	http.Redirect(w, r, "/general", http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/general", http.StatusSeeOther)
 }
 
 func (h *handler) general(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- correct redirect URL when navigating to `/ui/`

## Testing
- `go test ./...`
- `curl -I http://localhost:8081/ui/`

------
https://chatgpt.com/codex/tasks/task_b_68435bca5e70833093b8b00c9072606b