### PR TITLE
Add REST API and separate web UI

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+)
+
+func main() {
+	addr := flag.String("http", ":9090", "listen address")
+	dir := flag.String("static", "./web", "static content directory")
+	flag.Parse()
+
+	fs := http.FileServer(http.Dir(*dir))
+	http.Handle("/", fs)
+	log.Println("serving", *dir, "on", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/pod32g/proxy/internal/config"
+	"github.com/pod32g/proxy/internal/server"
+	log "github.com/pod32g/simple-logger"
+)
+
+// New returns a handler exposing REST APIs for runtime configuration.
+func New(cfg *config.Config, store *config.Store, logger *log.Logger, stats *server.DomainStats) http.Handler {
+	h := &handler{cfg: cfg, store: store, logger: logger, stats: stats}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/headers", h.headers)
+	mux.HandleFunc("/loglevel", h.logLevel)
+	mux.HandleFunc("/auth", h.auth)
+	mux.HandleFunc("/stats", h.statsHandler)
+	return mux
+}
+
+type handler struct {
+	cfg    *config.Config
+	store  *config.Store
+	logger *log.Logger
+	stats  *server.DomainStats
+}
+
+type headerReq struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Client string `json:"client"`
+}
+
+type logLevelReq struct {
+	Level string `json:"level"`
+}
+
+type authReq struct {
+	Enabled  bool   `json:"enabled"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type statsReq struct {
+	Enabled bool `json:"enabled"`
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *handler) headers(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, map[string]interface{}{
+			"global":  h.cfg.GetHeaders(),
+			"clients": h.cfg.GetAllClientHeaders(),
+		})
+	case http.MethodPost:
+		var req headerReq
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "" {
+			if req.Client == "" {
+				h.cfg.SetHeader(req.Name, req.Value)
+			} else {
+				h.cfg.SetClientHeader(req.Client, req.Name, req.Value)
+			}
+			if h.store != nil {
+				h.store.Save(h.cfg)
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	case http.MethodDelete:
+		var req headerReq
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "" {
+			if req.Client == "" {
+				h.cfg.DeleteHeader(req.Name)
+			} else {
+				h.cfg.DeleteClientHeader(req.Client, req.Name)
+			}
+			if h.store != nil {
+				h.store.Save(h.cfg)
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *handler) logLevel(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, map[string]string{"level": config.LevelString(h.cfg.GetLogLevel())})
+	case http.MethodPost:
+		var req logLevelReq
+		json.NewDecoder(r.Body).Decode(&req)
+		lvl := config.ParseLogLevel(req.Level)
+		h.cfg.SetLogLevel(lvl)
+		if h.logger != nil {
+			h.logger.SetLevel(lvl)
+		}
+		if h.store != nil {
+			h.store.Save(h.cfg)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *handler) auth(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		enabled, user, _ := h.cfg.GetAuth()
+		writeJSON(w, map[string]interface{}{"enabled": enabled, "username": user})
+	case http.MethodPost:
+		var req authReq
+		json.NewDecoder(r.Body).Decode(&req)
+		h.cfg.SetAuth(req.Enabled, req.Username, req.Password)
+		if h.logger != nil {
+			h.logger.Info("updated auth settings")
+		}
+		if h.store != nil {
+			h.store.Save(h.cfg)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *handler) statsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		data := map[string]interface{}{"enabled": h.cfg.StatsEnabledState()}
+		if h.stats != nil && h.cfg.StatsEnabledState() {
+			data["top"] = h.stats.Top(10)
+		}
+		writeJSON(w, data)
+	case http.MethodPost:
+		var req statsReq
+		json.NewDecoder(r.Body).Decode(&req)
+		h.cfg.SetStatsEnabled(req.Enabled)
+		if h.store != nil {
+			h.store.Save(h.cfg)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.NotFound(w, r)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pod32g/proxy/internal/api"
 	"github.com/pod32g/proxy/internal/config"
 	"github.com/pod32g/proxy/internal/proxy"
 	"github.com/pod32g/proxy/internal/server"
@@ -101,7 +102,8 @@ func main() {
 		handler = server.StatsMiddleware(h, stats, cfg.StatsEnabledState, func(r *http.Request) string { return target.Host })
 	}
 	uiHandler := ui.New(cfg, store, logger, tracker, stats)
-	mux := &server.Router{Proxy: handler, UI: uiHandler, AuthEnabled: cfg.AuthEnabled, Username: cfg.Username, Password: cfg.Password}
+	apiHandler := api.New(cfg, store, logger, stats)
+	mux := &server.Router{Proxy: handler, UI: uiHandler, API: apiHandler, AuthEnabled: cfg.AuthEnabled, Username: cfg.Username, Password: cfg.Password}
 
 	srv := server.Server{
 		HTTPAddr:  cfg.HTTPAddr,

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Proxy Configuration</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="container py-4">
+    <h1 class="mb-4">Proxy Configuration</h1>
+    <div id="headers" class="mb-4"></div>
+    <form id="addHeader" class="mb-3">
+        <div class="row g-2">
+            <div class="col"><input class="form-control" placeholder="Name" name="name"></div>
+            <div class="col"><input class="form-control" placeholder="Value" name="value"></div>
+            <div class="col"><input class="form-control" placeholder="Client" name="client"></div>
+            <div class="col"><button class="btn btn-primary" type="submit">Add</button></div>
+        </div>
+    </form>
+    <div class="mb-4">
+        <label>Log Level</label>
+        <select id="loglevel" class="form-select w-auto d-inline-block"></select>
+    </div>
+    <div id="stats" class="mt-4"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+    loadHeaders();
+    loadLogLevel();
+    loadStats();
+
+    document.getElementById('addHeader').addEventListener('submit', e => {
+        e.preventDefault();
+        const data = Object.fromEntries(new FormData(e.target).entries());
+        fetch('/api/headers', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        }).then(() => { e.target.reset(); loadHeaders(); });
+    });
+
+    document.getElementById('loglevel').addEventListener('change', e => {
+        fetch('/api/loglevel', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({level: e.target.value})
+        });
+    });
+});
+
+function loadHeaders() {
+    fetch('/api/headers').then(r => r.json()).then(data => {
+        let html = '<table class="table"><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody>';
+        for (const [k,v] of Object.entries(data.global)) {
+            html += `<tr><td>${k}</td><td>${v}</td></tr>`;
+        }
+        html += '</tbody></table>';
+        document.getElementById('headers').innerHTML = html;
+    });
+}
+
+function loadLogLevel() {
+    fetch('/api/loglevel').then(r => r.json()).then(data => {
+        const sel = document.getElementById('loglevel');
+        const levels = ['DEBUG','INFO','WARN','ERROR','FATAL'];
+        sel.innerHTML = levels.map(l => `<option${l===data.level?' selected':''}>${l}</option>`).join('');
+    });
+}
+
+function loadStats() {
+    fetch('/api/stats').then(r => r.json()).then(data => {
+        if (!data.enabled || !data.top) return;
+        let html = '<h2>Top Hosts</h2><ul class="list-group">';
+        for (const s of data.top) {
+            html += `<li class="list-group-item d-flex justify-content-between"><span>${s.Host}</span><span>${s.Count}</span></li>`;
+        }
+        html += '</ul>';
+        document.getElementById('stats').innerHTML = html;
+    });
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,3 @@
+body {
+    font-family: Arial, sans-serif;
+}


### PR DESCRIPTION
## Summary
- implement REST API endpoints for runtime configuration
- route `/api/` requests in the main router
- expose API from `main.go`
- add a simple standalone webserver for static assets
- provide HTML/JS/CSS files under `web/`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68435d5ba5508330becdf7007134b4cd