### PR TITLE
Disable HTTP/2 for TLS proxy

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -32,6 +33,7 @@ func (s *Server) Start() error {
 				ReadTimeout:  5 * time.Second,
 				WriteTimeout: 10 * time.Second,
 				IdleTimeout:  30 * time.Second,
+				TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 			}
 			if s.Clients != nil {
 				httpsSrv.ConnState = s.Clients.ConnState


### PR DESCRIPTION
## Summary
- avoid HTTP/2 when serving HTTPS so CONNECT works

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68436c70695083308c3290ffaf7f6401