### PR TITLE
Fix Mac OS TLS proxy error

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ func (s *Server) Start() error {
 				WriteTimeout: 10 * time.Second,
 				IdleTimeout:  30 * time.Second,
 				TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+				TLSConfig:    &tls.Config{NextProtos: []string{"http/1.1"}},
 			}
 			if s.Clients != nil {
 				httpsSrv.ConnState = s.Clients.ConnState


### PR DESCRIPTION
## Summary
- disable HTTP/2 by specifying HTTP/1.1 ALPN on the TLS server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68436e45197c83309ccd8da36a0a73cd