### PR TITLE
Skip ultra debug for HTTPS traffic

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -25,7 +25,7 @@ func NewForward(logger *log.Logger, headers func(string) map[string]string, ultr
 			return
 		}
 		logger.Debug("Forward proxy request", r.Method, sanitizedURL(r.URL))
-		if ultra != nil && ultra() {
+		if ultra != nil && ultra() && r.URL.Scheme != "https" {
 			if dump, err := httputil.DumpRequest(r, true); err == nil {
 				logger.Debug("forward request dump\n" + string(dump))
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -19,7 +19,7 @@ func New(target *url.URL, logger *log.Logger, headers func(string) map[string]st
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		logger.Debug("Reverse proxy request", req.Method, sanitizedURL(req.URL))
-		if ultra != nil && ultra() {
+		if ultra != nil && ultra() && target.Scheme != "https" {
 			if dump, err := httputil.DumpRequest(req, true); err == nil {
 				logger.Debug("reverse request dump\n" + string(dump))
 			}

--- a/internal/server/ultradebug.go
+++ b/internal/server/ultradebug.go
@@ -17,10 +17,13 @@ func UltraDebugMiddleware(next http.Handler, logger *log.Logger, enabled func() 
 			next.ServeHTTP(w, r)
 			return
 		}
-		if dump, err := httputil.DumpRequest(r, true); err == nil {
-			logger.Debug("full request\n" + string(dump))
-		} else {
-			logger.Debug("dump request error", err)
+		// Skip ultra debug logging for HTTPS and CONNECT requests.
+		if r.TLS == nil && r.Method != http.MethodConnect && r.URL.Scheme != "https" {
+			if dump, err := httputil.DumpRequest(r, true); err == nil {
+				logger.Debug("full request\n" + string(dump))
+			} else {
+				logger.Debug("dump request error", err)
+			}
 		}
 		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rw, r)


### PR DESCRIPTION
## Summary
- skip ultra debug logging when HTTPS is in use
- avoid dumping HTTPS requests in forward proxy
- avoid dumping HTTPS requests in reverse proxy

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68438411f2a48330bd1d2c16ef1f6e07