### PR TITLE
Disable debug logs for HTTPS

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,10 +18,12 @@ func New(target *url.URL, logger *log.Logger, headers func(string) map[string]st
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
-		logger.Debug("Reverse proxy request", req.Method, sanitizedURL(req.URL))
-		if ultra != nil && ultra() && target.Scheme != "https" {
-			if dump, err := httputil.DumpRequest(req, true); err == nil {
-				logger.Debug("reverse request dump\n" + string(dump))
+		if req.TLS == nil && target.Scheme != "https" {
+			logger.Debug("Reverse proxy request", req.Method, sanitizedURL(req.URL))
+			if ultra != nil && ultra() {
+				if dump, err := httputil.DumpRequest(req, true); err == nil {
+					logger.Debug("reverse request dump\n" + string(dump))
+				}
 			}
 		}
 		originalDirector(req)


### PR DESCRIPTION
## Summary
- skip forward proxy request logs when scheme is https
- remove `CONNECT` tunnel request log
- avoid reverse proxy logs for HTTPS
- don't log requests in debug middleware when HTTPS is used
- detect HTTPS scheme in debug middleware

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_684386c5e63c83308eefdd5c380c4ba8