### PR TITLE
Improve test coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pod32g/proxy/internal/config"
+	"github.com/pod32g/proxy/internal/server"
+)
+
+func newAPI() (*config.Config, http.Handler) {
+	cfg := &config.Config{}
+	h := New(cfg, nil, nil, server.NewDomainStats())
+	return cfg, h
+}
+
+func doReq(t *testing.T, h http.Handler, method, path string, body interface{}) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	if body != nil {
+		json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHeadersEndpoint(t *testing.T) {
+	cfg, h := newAPI()
+	doReq(t, h, "POST", "/headers", map[string]string{"name": "A", "value": "1"})
+	if v := cfg.GetHeaders()["A"]; v != "1" {
+		t.Fatalf("header not set")
+	}
+
+	rec := doReq(t, h, "GET", "/headers", nil)
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+
+	doReq(t, h, "DELETE", "/headers", map[string]string{"name": "A"})
+	if len(cfg.GetHeaders()) != 0 {
+		t.Fatalf("header not deleted")
+	}
+}
+
+func TestLogLevelEndpoint(t *testing.T) {
+	cfg, h := newAPI()
+	doReq(t, h, "POST", "/loglevel", map[string]string{"level": "DEBUG"})
+	if cfg.GetLogLevel() != config.ParseLogLevel("DEBUG") {
+		t.Fatalf("log level")
+	}
+	rec := doReq(t, h, "GET", "/loglevel", nil)
+	if rec.Code != 200 {
+		t.Fatalf("get status")
+	}
+}
+
+func TestAuthEndpoint(t *testing.T) {
+	cfg, h := newAPI()
+	doReq(t, h, "POST", "/auth", map[string]interface{}{"enabled": true, "username": "u", "password": "p"})
+	e, u, _ := cfg.GetAuth()
+	if !e || u != "u" {
+		t.Fatalf("auth")
+	}
+	rec := doReq(t, h, "GET", "/auth", nil)
+	if rec.Code != 200 {
+		t.Fatalf("get auth")
+	}
+}
+
+func TestIdentityEndpoint(t *testing.T) {
+	cfg, h := newAPI()
+	doReq(t, h, "POST", "/identity", map[string]string{"name": "n", "id": "i"})
+	n, id := cfg.GetIdentity()
+	if n != "n" || id != "i" {
+		t.Fatalf("identity")
+	}
+	rec := doReq(t, h, "GET", "/identity", nil)
+	if rec.Code != 200 {
+		t.Fatalf("get identity")
+	}
+}
+
+func TestStatsEndpoint(t *testing.T) {
+	cfg, h := newAPI()
+	doReq(t, h, "POST", "/stats", map[string]bool{"enabled": true})
+	if !cfg.StatsEnabledState() {
+		t.Fatalf("stats not enabled")
+	}
+	rec := doReq(t, h, "GET", "/stats", nil)
+	if rec.Code != 200 {
+		t.Fatalf("get stats")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	log "github.com/pod32g/simple-logger"
+	"strings"
+	"testing"
+)
+
+func TestHeaderManagement(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetHeader("A", "1")
+	cfg.SetClientHeader("client1", "B", "2")
+	hdrs := cfg.GetHeadersForClient("client1")
+	if hdrs["A"] != "1" || hdrs["B"] != "2" {
+		t.Fatalf("unexpected headers: %#v", hdrs)
+	}
+	cfg.DeleteClientHeader("client1", "B")
+	hdrs = cfg.GetHeadersForClient("client1")
+	if _, ok := hdrs["B"]; ok {
+		t.Fatalf("client header not deleted")
+	}
+	cfg.DeleteHeader("A")
+	if len(cfg.GetHeaders()) != 0 {
+		t.Fatalf("expected global header deleted")
+	}
+}
+
+func TestLogLevelParseAndString(t *testing.T) {
+	levels := []struct {
+		str string
+		lvl log.LogLevel
+	}{
+		{"DEBUG", log.DEBUG},
+		{"INFO", log.INFO},
+		{"WARN", log.WARN},
+		{"ERROR", log.ERROR},
+		{"FATAL", log.FATAL},
+		{"OTHER", log.INFO},
+	}
+	for _, tt := range levels {
+		if ParseLogLevel(tt.str) != tt.lvl {
+			t.Fatalf("ParseLogLevel failed for %s", tt.str)
+		}
+		if LevelString(tt.lvl) != strings.ToUpper(tt.str) && tt.str != "OTHER" {
+			t.Fatalf("LevelString failed for %s", tt.str)
+		}
+	}
+}
+
+func TestAuthIdentityStats(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetAuth(true, "user", "pass")
+	if e, u, p := cfg.GetAuth(); !e || u != "user" || p != "pass" {
+		t.Fatalf("unexpected auth: %v %s %s", e, u, p)
+	}
+	cfg.SetIdentity("name", "id")
+	n, id := cfg.GetIdentity()
+	if n != "name" || id != "id" {
+		t.Fatalf("unexpected identity")
+	}
+	cfg.SetStatsEnabled(true)
+	if !cfg.StatsEnabledState() {
+		t.Fatalf("stats not enabled")
+	}
+}

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	log "github.com/pod32g/simple-logger"
+	"os"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	enc, err := encrypt("key", "data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := decrypt("key", enc)
+	if err != nil || dec != "data" {
+		t.Fatalf("decrypt mismatch: %v %s", err, dec)
+	}
+}
+
+func TestStoreSaveLoad(t *testing.T) {
+	f, err := os.CreateTemp("", "db-*.sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{SecretKey: "k"}
+	cfg.SetHeader("H", "v")
+	cfg.SetLogLevel(log.DEBUG)
+	cfg.SetAuth(true, "u", "p")
+	cfg.SetStatsEnabled(true)
+	cfg.SetIdentity("n", "id")
+	if err := store.Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+	loaded := &Config{SecretKey: "k"}
+	if err := store.Load(loaded); err != nil {
+		t.Fatal(err)
+	}
+	if loaded.GetHeaders()["H"] != "v" || loaded.GetLogLevel() != log.DEBUG {
+		t.Fatalf("load mismatch")
+	}
+	e, u, p := loaded.GetAuth()
+	if !e || u != "u" || p != "p" {
+		t.Fatalf("auth mismatch")
+	}
+	if !loaded.StatsEnabledState() {
+		t.Fatalf("stats mismatch")
+	}
+	n, id2 := loaded.GetIdentity()
+	if n != "n" || id2 != "id" {
+		t.Fatalf("id mismatch")
+	}
+	store.Close()
+}

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestMetricsMiddleware(t *testing.T) {
+	metrics := NewMetrics()
+	handler := MetricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(201) }), metrics)
+	req := httptest.NewRequest("POST", "http://host/", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if code := rw.Result().StatusCode; code != 201 {
+		t.Fatalf("status %d", code)
+	}
+	if v := testutil.ToFloat64(metrics.Requests.WithLabelValues("POST", "201")); v != 1 {
+		t.Fatalf("requests metric %f", v)
+	}
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStatsMiddleware(t *testing.T) {
+	ds := NewDomainStats()
+	mw := StatsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), ds, func() bool { return true }, func(r *http.Request) string { return r.Host })
+	req := httptest.NewRequest("GET", "http://example.com:8080/", nil)
+	rw := httptest.NewRecorder()
+	mw.ServeHTTP(rw, req)
+	top := ds.Top(1)
+	if len(top) != 1 || top[0].Host != "example.com" {
+		t.Fatalf("stats not recorded: %v", top)
+	}
+}
+
+func TestStatsMiddlewareDisabled(t *testing.T) {
+	ds := NewDomainStats()
+	mw := StatsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), ds, func() bool { return false }, func(r *http.Request) string { return r.Host })
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	rw := httptest.NewRecorder()
+	mw.ServeHTTP(rw, req)
+	if len(ds.Top(1)) != 0 {
+		t.Fatalf("stats should be empty")
+	}
+}

--- a/internal/server/tracker_test.go
+++ b/internal/server/tracker_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type stubAddr struct{ addr string }
+
+func (s stubAddr) Network() string { return "tcp" }
+func (s stubAddr) String() string  { return s.addr }
+
+type stubConn struct {
+	net.Conn
+	raddr net.Addr
+}
+
+func (s stubConn) RemoteAddr() net.Addr { return s.raddr }
+
+func TestClientTracker(t *testing.T) {
+	ct := NewClientTracker()
+	g := prometheus.NewGauge(prometheus.GaugeOpts{})
+	ct.SetGauge(g)
+	ch := ct.Subscribe()
+	if <-ch != 0 {
+		t.Fatalf("initial count")
+	}
+
+	c := stubConn{raddr: stubAddr{addr: "1.2.3.4:5"}}
+	ct.ConnState(c, http.StateNew)
+	if ct.Count() != 1 {
+		t.Fatalf("count=1 expected")
+	}
+	if testutil.ToFloat64(g) != 1 {
+		t.Fatalf("gauge not updated")
+	}
+	addrs := ct.Addrs()
+	if len(addrs) != 1 || addrs[0] != "1.2.3.4" {
+		t.Fatalf("addrs wrong: %v", addrs)
+	}
+
+	ct.ConnState(c, http.StateClosed)
+	if ct.Count() != 0 {
+		t.Fatalf("count=0 expected")
+	}
+	ct.Unsubscribe(ch)
+	time.Sleep(10 * time.Millisecond) // allow async update
+}


### PR DESCRIPTION
## Summary
- add unit tests for config package
- add unit tests for config store
- cover API handlers
- test client tracker, middleware and metrics middleware
- tidy module dependencies

## Testing
- `go test ./... -run Test -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_b_686213d88af48330acb18ed971e98b3a