### PR TITLE
Add coverage to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests with coverage
+        run: |
+          go test -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out


### PR DESCRIPTION
## Summary
- generate coverage data when running go tests
- upload the `coverage.out` artifact for inspection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686215a46ffc83309b9c1a58f1029b81