### PR TITLE
Improve test coverage

### DIFF
--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/pod32g/proxy/internal/config"
+    "github.com/pod32g/proxy/internal/server"
+)
+
+func TestIndexRedirect(t *testing.T) {
+    cfg := &config.Config{}
+    h := New(cfg, nil, nil, nil, nil)
+    rec := httptest.NewRecorder()
+    req := httptest.NewRequest("GET", "/", nil)
+    h.ServeHTTP(rec, req)
+    if rec.Code != http.StatusSeeOther {
+        t.Fatalf("expected redirect, got %d", rec.Code)
+    }
+}
+
+func TestEventsUnavailable(t *testing.T) {
+    cfg := &config.Config{}
+    h := New(cfg, nil, nil, nil, nil)
+    rec := httptest.NewRecorder()
+    req := httptest.NewRequest("GET", "/events", nil)
+    h.ServeHTTP(rec, req)
+    if rec.Code != http.StatusServiceUnavailable {
+        t.Fatalf("expected 503, got %d", rec.Code)
+    }
+}
+
+func TestStatsEventsUnavailable(t *testing.T) {
+    cfg := &config.Config{}
+    h := New(cfg, nil, nil, nil, server.NewDomainStats())
+    rec := httptest.NewRecorder()
+    req := httptest.NewRequest("GET", "/stats-events", nil)
+    h.ServeHTTP(rec, req)
+    if rec.Code != http.StatusServiceUnavailable {
+        t.Fatalf("expected 503, got %d", rec.Code)
+    }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestGetenv(t *testing.T) {
+    key := "TEST_ENV_VAR"
+    if got := getenv(key, "default"); got != "default" {
+        t.Fatalf("expected default, got %s", got)
+    }
+    t.Setenv(key, "value")
+    if got := getenv(key, "default"); got != "value" {
+        t.Fatalf("expected value, got %s", got)
+    }
+}
+
+func TestHeaderFlags(t *testing.T) {
+    var h headerFlags
+    if err := h.Set("A=1"); err != nil {
+        t.Fatalf("Set returned error: %v", err)
+    }
+    if h.String() != "A=1" {
+        t.Fatalf("unexpected string: %s", h.String())
+    }
+    if err := h.Set("badformat"); err == nil {
+        t.Fatalf("expected error for bad format")
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for getenv and header flag helpers
- add minimal tests for UI handler

## Testing
- `go test ./... -cover -count=1`


------
https://chatgpt.com/codex/tasks/task_b_686216b273888330b9c766abde97d7cb